### PR TITLE
request service should be removed before changing his definition

### DIFF
--- a/src/Codeception/Lib/Connector/Phalcon4.php
+++ b/src/Codeception/Lib/Connector/Phalcon4.php
@@ -3,17 +3,17 @@
 namespace Codeception\Lib\Connector;
 
 use Closure;
+use Codeception\Lib\Connector\Shared\PhpSuperGlobalsConverter;
+use Codeception\Util\Stub;
 use Phalcon\Di;
 use Phalcon\Http;
-use RuntimeException;
-use ReflectionProperty;
-use Codeception\Util\Stub;
 use Phalcon\Mvc\Application;
-use Symfony\Component\BrowserKit\Cookie;
-use Symfony\Component\BrowserKit\AbstractBrowser as Client;
 use Phalcon\Mvc\Micro as MicroApplication;
+use ReflectionProperty;
+use RuntimeException;
+use Symfony\Component\BrowserKit\AbstractBrowser as Client;
+use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\BrowserKit\Response;
-use Codeception\Lib\Connector\Shared\PhpSuperGlobalsConverter;
 
 class Phalcon4 extends Client
 {
@@ -110,6 +110,9 @@ class Phalcon4 extends Client
         Di::reset();
         Di::setDefault($di);
 
+        if ($di->has('request')) {
+            $di->remove('request');
+        }
         $di['request'] = Stub::construct($phRequest, [], ['getRawBody' => $request->getContent()]);
 
         $response = $application->handle($pathString);

--- a/tests/_data/bootstrap-micro.php
+++ b/tests/_data/bootstrap-micro.php
@@ -1,3 +1,4 @@
 <?php
+
 $di = new \Phalcon\DI\FactoryDefault();
 return new \Phalcon\Mvc\Micro($di);

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -1,6 +1,5 @@
 <?php
 
-
 /**
  * Inherited Methods
  * @method void wantToTest($text)

--- a/tests/_support/FunctionalTester.php
+++ b/tests/_support/FunctionalTester.php
@@ -1,6 +1,5 @@
 <?php
 
-
 /**
  * Inherited Methods
  * @method void wantToTest($text)

--- a/tests/_support/UnitTester.php
+++ b/tests/_support/UnitTester.php
@@ -1,6 +1,5 @@
 <?php
 
-
 /**
  * Inherited Methods
  * @method void wantToTest($text)

--- a/tests/unit/Phalcon4ConnectorTest.php
+++ b/tests/unit/Phalcon4ConnectorTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+use Codeception\Lib\Connector\Phalcon4 as PhalconConnector;
+use Codeception\Module\Phalcon4;
+use Symfony\Component\BrowserKit\Request;
+
+class Phalcon4ConnectorTest extends \Codeception\Test\Unit
+{
+    protected function getPhalconModule(): Phalcon4
+    {
+        $container = \Codeception\Util\Stub::make('Codeception\Lib\ModuleContainer');
+        $module = new Phalcon4($container);
+        $module->_setConfig([
+            'bootstrap'  => 'tests/_data/bootstrap.php',
+            'cleanup'    => true,
+            'savepoints' => true,
+            'session'    => 'Codeception\Lib\Connector\Phalcon4\MemorySession'
+        ]);
+        $module->_initialize();
+        return $module;
+    }
+
+    public function testConstruct(): void
+    {
+        $connector = new PhalconConnector();
+        $this->assertInstanceOf(PhalconConnector::class, $connector);
+    }
+
+    public function testDoRequest(): void
+    {
+        $module = $this->getPhalconModule();
+        $test = new Codeception\Test\Unit();
+        $module->_before($test);
+
+        $connector = $module->client;
+
+        // parameters for Request object
+        $uri = '/';
+        $method = 'GET';
+        $params = [
+            'first' => 'one',
+            'second' => 'two'
+        ];
+        $files = [
+            'file' => [
+                'name' => 'SomeFile.ext',
+                'tmp_name' => 'SomeFile.ext',
+                'error' => false
+            ]
+        ];
+        $cookies = [
+            'token' => 'asdev257'
+        ];
+        $server = [
+            'HTTP_HOST' => 'localhost',
+            'SERVER_NAME' => 'my pc',
+            'SERVER_ADDR' => '127.0.0.1',
+        ];
+        $content = "this is request content";
+
+        $request = new Request(
+            $uri,
+            $method,
+            $params,
+            $files,
+            $cookies,
+            $server,
+            $content
+        );
+
+        // send request
+        $response = $connector->doRequest($request);
+        $this->assertSame(200, $response->getStatusCode());
+
+        /** @var Phalcon\Http\Request $requestService*/
+        $requestService = $module->grabServiceFromContainer('request');
+
+        // assert request uri
+        $this->assertSame($uri, $requestService->getURI());
+
+        // assert request method
+        $this->assertSame($method, $requestService->getMethod());
+
+        // assert reques paramters
+        $this->assertSame($params['first'], $requestService->get('first'));
+        $this->assertSame($params['second'], $requestService->get('second'));
+
+        // assert uploaded file
+        $this->assertTrue($requestService->hasFiles());
+        /** @var Phalcon\Http\Request\File $uploadedFile */
+        $uploadedFile = $requestService->getUploadedFiles()[0];
+        $this->assertSame($files['file']['name'], $uploadedFile->getName());
+        $this->assertSame($files['file']['tmp_name'], $uploadedFile->getTempName());
+        $this->assertSame('ext', $uploadedFile->getExtension());
+
+        // assert server parameter
+        $this->assertSame($server['HTTP_HOST'], $requestService->getServer('HTTP_HOST'));
+
+        // assert request body
+        $this->assertSame($content, $requestService->getRawBody());
+
+        $module->_after($test);
+    }
+}


### PR DESCRIPTION
Without this change its not possible fill content to request body using `_request()` method.

I add some more info:

I had problem set json content to _request() method. After some research, diging into code i realize, it is not possible replace shared service with other shared service. One can replace shared service only with non-shared service.

```php
$di->set('service', {some_definition}, true);
// this line does not change service.
$di->set('service', {some_other_definition}, true);
// this line change service
$di->set('service', {some_other_definition}, false);
```
Its not possible change shared service with "array' notation like this:

```php
$di->set('service', {some_definition}, true);
// this line does not change service.
$di['service'] =  {some_other_definition};
```

Using "array" notation you only change service definition. but if shared service is resolved before, changing definition has not effect on next geting service