### PR TITLE
Adjusting Session To Use Session Manager

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ DB_HOST=127.0.0.1
 DB_NAME=phalcon
 DB_USERNAME=root
 DB_PASSWORD=password
+DB_PORT=3306

--- a/src/Codeception/Lib/Connector/Phalcon4/MemorySession.php
+++ b/src/Codeception/Lib/Connector/Phalcon4/MemorySession.php
@@ -295,4 +295,27 @@ class MemorySession extends AbstractAdapter
     {
         return md5(time());
     }
+
+    /**
+     * Dummy - We Don't Actually Read Anything
+     *
+     * @return string
+     */
+    public function read($id): string
+    {
+        return "";
+    }
+
+    /**
+     * Write - We Don't Actually Write Anything
+     *
+     * @param $id
+     * @param $data
+     *
+     * @return bool
+     */
+    public function write($id, $data): bool
+    {
+        return true;
+    }
 }

--- a/src/Codeception/Lib/Connector/Phalcon4/SessionManager.php
+++ b/src/Codeception/Lib/Connector/Phalcon4/SessionManager.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Codeception\Lib\Connector\Phalcon4;
+
+use Phalcon\Session\Manager;
+
+class SessionManager extends Manager
+{
+    /**
+     * We have to override this as otherwise nothing working correctly in testing.
+     *
+     * @return bool
+     */
+    public function exists(): bool
+    {
+        return true;
+    }
+}

--- a/src/Codeception/Module/Phalcon4.php
+++ b/src/Codeception/Module/Phalcon4.php
@@ -12,6 +12,7 @@ use Codeception\Lib\Interfaces\ActiveRecord;
 use Codeception\Lib\Interfaces\PartedModule;
 use Codeception\TestInterface;
 use Codeception\Util\ReflectionHelper;
+use Exception;
 use PDOException;
 use Phalcon\Di;
 use Phalcon\Di\Injectable;
@@ -19,7 +20,7 @@ use Phalcon\DiInterface;
 use Phalcon\Mvc\Model as PhalconModel;
 use Phalcon\Mvc\Router\RouteInterface;
 use Phalcon\Mvc\RouterInterface;
-use Phalcon\Session\Manager;
+use Codeception\Lib\Connector\Phalcon4\SessionManager;
 use Phalcon\Url;
 
 /**
@@ -152,11 +153,10 @@ class Phalcon4 extends Framework implements ActiveRecord, PartedModule
 
         if ($this->di->has('session')) {
             /** @var Manager $manager */
-            $manager = $this->di->get(Manager::class);
+            $manager = $this->di->get(SessionManager::class);
             $manager->setAdapter(
                 $this->di->get($this->config['session'])
             );
-            $manager->start();
 
             // Destroy existing sessions of previous tests
             $this->di['session'] = $manager;

--- a/src/Codeception/Module/Phalcon4.php
+++ b/src/Codeception/Module/Phalcon4.php
@@ -19,6 +19,7 @@ use Phalcon\DiInterface;
 use Phalcon\Mvc\Model as PhalconModel;
 use Phalcon\Mvc\Router\RouteInterface;
 use Phalcon\Mvc\RouterInterface;
+use Phalcon\Session\Manager;
 use Phalcon\Url;
 
 /**
@@ -150,8 +151,15 @@ class Phalcon4 extends Framework implements ActiveRecord, PartedModule
         Di::setDefault($this->di);
 
         if ($this->di->has('session')) {
+            /** @var Manager $manager */
+            $manager = $this->di->get(Manager::class);
+            $manager->setAdapter(
+                $this->di->get($this->config['session'])
+            );
+            $manager->start();
+
             // Destroy existing sessions of previous tests
-            $this->di['session'] = $this->di->get($this->config['session']);
+            $this->di['session'] = $manager;
         }
 
         if ($this->di->has('cookies')) {

--- a/src/Codeception/Module/Phalcon4.php
+++ b/src/Codeception/Module/Phalcon4.php
@@ -231,7 +231,7 @@ class Phalcon4 extends Framework implements ActiveRecord, PartedModule
     public function haveInSession($key, $val)
     {
         $this->di->get('session')->set($key, $val);
-        $this->debugSection('Session', json_encode($this->di['session']->toArray()));
+        $this->debugSection('Session', json_encode($this->di['session']->getAdapter()->toArray()));
     }
 
     /**
@@ -250,7 +250,7 @@ class Phalcon4 extends Framework implements ActiveRecord, PartedModule
      */
     public function seeInSession($key, $value = null)
     {
-        $this->debugSection('Session', json_encode($this->di['session']->toArray()));
+        $this->debugSection('Session', json_encode($this->di['session']->getAdapter()->toArray()));
 
         if (is_array($key)) {
             $this->seeSessionHasValues($key);

--- a/tests/_data/bootstrap-micro.php
+++ b/tests/_data/bootstrap-micro.php
@@ -1,3 +1,4 @@
 <?php
+
 $di = new \Phalcon\DI\FactoryDefault();
 return new \Phalcon\Mvc\Micro($di);

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -3,6 +3,7 @@
 
 /**
  * Inherited Methods
+ *
  * @method void wantToTest($text)
  * @method void wantTo($text)
  * @method void execute($callable)

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -1,6 +1,5 @@
 <?php
 
-
 /**
  * Inherited Methods
  *

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -16,6 +16,7 @@
  *
  * @SuppressWarnings(PHPMD)
 */
+
 class AcceptanceTester extends \Codeception\Actor
 {
     use _generated\AcceptanceTesterActions;

--- a/tests/_support/FunctionalTester.php
+++ b/tests/_support/FunctionalTester.php
@@ -3,6 +3,7 @@
 
 /**
  * Inherited Methods
+ *
  * @method void wantToTest($text)
  * @method void wantTo($text)
  * @method void execute($callable)

--- a/tests/_support/FunctionalTester.php
+++ b/tests/_support/FunctionalTester.php
@@ -16,6 +16,7 @@
  *
  * @SuppressWarnings(PHPMD)
 */
+
 class FunctionalTester extends \Codeception\Actor
 {
     use _generated\FunctionalTesterActions;

--- a/tests/_support/FunctionalTester.php
+++ b/tests/_support/FunctionalTester.php
@@ -1,6 +1,5 @@
 <?php
 
-
 /**
  * Inherited Methods
  *

--- a/tests/_support/UnitTester.php
+++ b/tests/_support/UnitTester.php
@@ -3,6 +3,7 @@
 
 /**
  * Inherited Methods
+ *
  * @method void wantToTest($text)
  * @method void wantTo($text)
  * @method void execute($callable)

--- a/tests/_support/UnitTester.php
+++ b/tests/_support/UnitTester.php
@@ -1,6 +1,5 @@
 <?php
 
-
 /**
  * Inherited Methods
  *

--- a/tests/_support/UnitTester.php
+++ b/tests/_support/UnitTester.php
@@ -16,6 +16,7 @@
  *
  * @SuppressWarnings(PHPMD)
 */
+
 class UnitTester extends \Codeception\Actor
 {
     use _generated\UnitTesterActions;

--- a/tests/unit/Phalcon4ModuleTest.php
+++ b/tests/unit/Phalcon4ModuleTest.php
@@ -140,7 +140,8 @@ class Phalcon4ModuleTest extends \Codeception\Test\Unit
         $module->_before($test);
 
         $session = $module->grabServiceFromContainer('session');
-        $this->assertInstanceOf('Codeception\Lib\Connector\Phalcon4\MemorySession', $session);
+        $this->assertInstanceOf('Phalcon\Session\Manager', $session);
+        $this->assertInstanceOf('Codeception\Lib\Connector\Phalcon4\MemorySession', $session->getAdapter());
 
         $testService = $module->addServiceToContainer('std', function () {
             return new \stdClass();


### PR DESCRIPTION
MemorySession is no longer compatible with the new Adapter setup. This does two things.

1. Ensure Memory Is Compatible With AbstractAdapter
1. Adjust Functional Suite To Use Manager With MemorySession

I Believe This Resolves #8 