### PR TITLE
Remove '<8.0' requirement in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": ">=7.2.0 <8.0",
+        "php": ">=7.2.0",
         "ext-phalcon": ">=4",
         "codeception/codeception": "^4.0",
         "codeception/lib-innerbrowser": "^1.0",


### PR DESCRIPTION
For PHP8 support in `4.2` version.

PR - https://github.com/phalcon/cphalcon/pull/15287