### PR TITLE
Code standards updated to PHP 7.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,41 +1,43 @@
 {
-    "name":"codeception/module-phalcon4",
-    "description":"Codeception module for Phalcon 4 framework",
-    "keywords":["codeception", "phalcon", "phalcon4"],
-    "homepage":"https://codeception.com/",
-    "type":"library",
-    "license":"MIT",
-    "authors": [
-        {
-            "name": "Phalcon Team",
-            "email": "team@phalcon.io",
-            "homepage": "https://phalcon.io/en/team"
-        },
-        {
-            "name": "Codeception Team",
-            "email": "team@codeception.com",
-            "homepage": "http://codeception.com/"
-        }
-    ],
-    "require": {
-        "php": ">=7.2.0",
-        "ext-phalcon": ">=4",
-        "codeception/codeception": "^4.0",
-        "codeception/lib-innerbrowser": "^1.0",
-        "codeception/module-asserts": "^1.0",
-        "codeception/module-phpbrowser": "^1.0",
-        "codeception/module-db": "^1.0"
-    },
-    "require-dev": {
-        "codeception/util-robohelpers": "dev-master",
-        "vlucas/phpdotenv": "^4.1",
-        "squizlabs/php_codesniffer": "^3.4",
-        "vimeo/psalm": "^3.6"
-    },
-    "autoload":{
-        "classmap": ["src/"]
-    },
-    "config": {
-        "classmap-authoritative": true
-    }
+	"name": "codeception/module-phalcon4",
+	"description": "Codeception module for Phalcon 4 framework",
+	"keywords": [ "codeception", "phalcon", "phalcon4" ],
+	"homepage": "https://codeception.com/",
+	"type": "library",
+	"license": "MIT",
+	"authors": [
+		{
+			"name": "Phalcon Team",
+			"email": "team@phalcon.io",
+			"homepage": "https://phalcon.io/en/team"
+		},
+		{
+			"name": "Codeception Team",
+			"email": "team@codeception.com",
+			"homepage": "https://codeception.com/"
+		}
+	],
+	"require": {
+		"php": ">=7.2.0",
+		"ext-json": "*",
+		"codeception/codeception": "^4.0",
+		"codeception/lib-innerbrowser": "^1.0",
+		"codeception/module-asserts": "^1.0",
+		"codeception/module-phpbrowser": "^1.0",
+		"codeception/module-db": "^1.0"
+	},
+	"require-dev": {
+		"codeception/util-robohelpers": "dev-master",
+		"vlucas/phpdotenv": "^4.1",
+		"squizlabs/php_codesniffer": "^3.4",
+		"vimeo/psalm": "^3.6"
+	},
+	"autoload": {
+		"classmap": [
+			"src/"
+		]
+	},
+	"config": {
+		"classmap-authoritative": true
+	}
 }

--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,10 @@ A Codeception module for Phalcon4 framework
 [![Total Downloads](https://poser.pugx.org/codeception/module-phalcon4/downloads)](https://packagist.org/packages/codeception/module-phalcon4)
 [![License](https://poser.pugx.org/codeception/module-phalcon4/license)](/LICENSE)
 
+## Requirements
+
+* `PHP 7.2` or higher.
+
 ## Installation
 
 ```

--- a/src/Codeception/Lib/Connector/Phalcon4/MemorySession.php
+++ b/src/Codeception/Lib/Connector/Phalcon4/MemorySession.php
@@ -1,8 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Lib\Connector\Phalcon4;
 
 use Phalcon\Session\Adapter\AbstractAdapter;
+use Phalcon\Session\AdapterInterface;
 
 class MemorySession extends AbstractAdapter
 {
@@ -43,7 +46,7 @@ class MemorySession extends AbstractAdapter
     /**
      * @inheritdoc
      */
-    public function start()
+    public function start(): bool
     {
         if ($this->status() !== PHP_SESSION_ACTIVE) {
             $this->memory = [];
@@ -60,7 +63,7 @@ class MemorySession extends AbstractAdapter
      *
      * @param array $options
      */
-    public function setOptions(array $options)
+    public function setOptions(array $options): void
     {
         if (isset($options['uniqueId'])) {
             $this->sessionId = $options['uniqueId'];
@@ -74,7 +77,7 @@ class MemorySession extends AbstractAdapter
      *
      * @return array
      */
-    public function getOptions()
+    public function getOptions(): array
     {
         return $this->options;
     }
@@ -87,7 +90,7 @@ class MemorySession extends AbstractAdapter
      * @param bool $remove
      * @return mixed
      */
-    public function get($index, $defaultValue = null, $remove = false)
+    public function get(string $index, $defaultValue = null, bool $remove = false)
     {
         $key = $this->prepareIndex($index);
 
@@ -110,7 +113,7 @@ class MemorySession extends AbstractAdapter
      * @param string $index
      * @param mixed $value
      */
-    public function set($index, $value)
+    public function set(string $index, $value): void
     {
         $this->memory[$this->prepareIndex($index)] = $value;
     }
@@ -121,7 +124,7 @@ class MemorySession extends AbstractAdapter
      * @param string $index
      * @return bool
      */
-    public function has($index)
+    public function has(string $index): bool
     {
         return isset($this->memory[$this->prepareIndex($index)]);
     }
@@ -131,7 +134,7 @@ class MemorySession extends AbstractAdapter
      *
      * @param string $index
      */
-    public function remove($index)
+    public function remove(string $index): void
     {
         unset($this->memory[$this->prepareIndex($index)]);
     }
@@ -141,7 +144,7 @@ class MemorySession extends AbstractAdapter
      *
      * @return string
      */
-    public function getId()
+    public function getId(): string
     {
         return $this->sessionId;
     }
@@ -151,7 +154,7 @@ class MemorySession extends AbstractAdapter
      *
      * @return bool
      */
-    public function isStarted()
+    public function isStarted(): bool
     {
         return $this->started;
     }
@@ -164,12 +167,11 @@ class MemorySession extends AbstractAdapter
      * if ($session->status() !== PHP_SESSION_ACTIVE) {
      *     $session->start();
      * }
-     * ?>
      * ```
      *
      * @return int
      */
-    public function status()
+    public function status(): int
     {
         if ($this->isStarted()) {
             return PHP_SESSION_ACTIVE;
@@ -181,7 +183,7 @@ class MemorySession extends AbstractAdapter
     /**
      * @inheritdoc
      *
-     * @param bool $removeData
+     * @param bool $id
      * @return bool
      */
     public function destroy($id): bool
@@ -195,9 +197,9 @@ class MemorySession extends AbstractAdapter
      * @inheritdoc
      *
      * @param bool $deleteOldSession
-     * @return \Phalcon\Session\AdapterInterface
+     * @return AdapterInterface
      */
-    public function regenerateId($deleteOldSession = true)
+    public function regenerateId(bool $deleteOldSession = true): AdapterInterface
     {
         $this->sessionId = $this->generateId();
 
@@ -209,7 +211,7 @@ class MemorySession extends AbstractAdapter
      *
      * @param string $name
      */
-    public function setName($name)
+    public function setName(string $name): void
     {
         $this->name = $name;
     }
@@ -219,7 +221,7 @@ class MemorySession extends AbstractAdapter
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -229,7 +231,7 @@ class MemorySession extends AbstractAdapter
      *
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
         return (array) $this->memory;
     }
@@ -240,7 +242,7 @@ class MemorySession extends AbstractAdapter
      * @param string $index
      * @return mixed
      */
-    public function __get($index)
+    public function __get(string $index)
     {
         return $this->get($index);
     }
@@ -251,7 +253,7 @@ class MemorySession extends AbstractAdapter
      * @param string $index
      * @param mixed $value
      */
-    public function __set($index, $value)
+    public function __set(string $index, $value): void
     {
         $this->set($index, $value);
     }
@@ -259,10 +261,10 @@ class MemorySession extends AbstractAdapter
     /**
      * Alias: Check whether a session variable is set in an application context
      *
-     * @param  string $index
+     * @param string $index
      * @return bool
      */
-    public function __isset($index)
+    public function __isset(string $index): bool
     {
         return $this->has($index);
     }
@@ -272,12 +274,12 @@ class MemorySession extends AbstractAdapter
      *
      * @param string $index
      */
-    public function __unset($index)
+    public function __unset(string $index): void
     {
         $this->remove($index);
     }
 
-    private function prepareIndex($index)
+    private function prepareIndex(string $index): string
     {
         if ($this->sessionId) {
             $key = $this->sessionId . '#' . $index;
@@ -291,9 +293,9 @@ class MemorySession extends AbstractAdapter
     /**
      * @return string
      */
-    private function generateId()
+    private function generateId(): string
     {
-        return md5(time());
+        return sha1((string) time());
     }
 
     /**

--- a/src/Codeception/Lib/Connector/Phalcon4/SessionManager.php
+++ b/src/Codeception/Lib/Connector/Phalcon4/SessionManager.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Lib\Connector\Phalcon4;
 
 use Phalcon\Session\Manager;

--- a/tests/unit/MemorySessionTest.php
+++ b/tests/unit/MemorySessionTest.php
@@ -1,9 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 use Codeception\Lib\Connector\Phalcon4\MemorySession;
 use Codeception\Util\Autoload;
 
-class MemorySessionTest extends \Codeception\Test\Unit
+final class MemorySessionTest extends \Codeception\Test\Unit
 {
     /**
      * @var \UnitTester

--- a/tests/unit/Phalcon4ConnectorTest.php
+++ b/tests/unit/Phalcon4ConnectorTest.php
@@ -6,7 +6,7 @@ use Codeception\Lib\Connector\Phalcon4 as PhalconConnector;
 use Codeception\Module\Phalcon4;
 use Symfony\Component\BrowserKit\Request;
 
-class Phalcon4ConnectorTest extends \Codeception\Test\Unit
+final class Phalcon4ConnectorTest extends \Codeception\Test\Unit
 {
     protected function getPhalconModule(): Phalcon4
     {

--- a/tests/unit/Phalcon4ModuleTest.php
+++ b/tests/unit/Phalcon4ModuleTest.php
@@ -1,9 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 use Codeception\Module\Phalcon4;
 use Codeception\Exception\ModuleConfigException;
 
-class Phalcon4ModuleTest extends \Codeception\Test\Unit
+final class Phalcon4ModuleTest extends \Codeception\Test\Unit
 {
     /**
      * @var \UnitTester


### PR DESCRIPTION
- Added strict types
- Added return types
- Added some typehints
- Removed unnecessary qualifiers
- sha1 by default instead of md5.