### PR TITLE
Fix Phalcon bug where Expiration is returned as int

### DIFF
--- a/src/Codeception/Lib/Connector/Phalcon4.php
+++ b/src/Codeception/Lib/Connector/Phalcon4.php
@@ -149,7 +149,7 @@ class Phalcon4 extends AbstractBrowser
                     $clientCookie = new Cookie(
                         $name,
                         $valueProperty->getValue($cookie),
-                        $cookie->getExpiration(),
+                        (string)$cookie->getExpiration(),
                         $cookie->getPath(),
                         $cookie->getDomain(),
                         $cookie->getSecure(),


### PR DESCRIPTION
Phalcons Cookie claims to return a string, but the actual code is an int returned.

The constructor only  takes it as an int: https://github.com/phalcon/cphalcon/blob/4.1.2-release/phalcon/Http/Cookie.zep#L98
The property is mixed (but loosely typed as int): https://github.com/phalcon/cphalcon/blob/4.1.2-release/phalcon/Http/Cookie.zep#L37
The return function is marked as string: https://github.com/phalcon/cphalcon/blob/4.1.2-release/phalcon/Http/Cookie.zep#L193
The setter function is also typed to int: https://github.com/phalcon/cphalcon/blob/4.1.2-release/phalcon/Http/Cookie.zep#L555

If necessary, I can provide an screenshot of the debug information that occurs.