### PR TITLE
Fix getApplication() type hint

### DIFF
--- a/src/Codeception/Module/Phalcon4.php
+++ b/src/Codeception/Module/Phalcon4.php
@@ -226,7 +226,7 @@ class Phalcon4 extends Framework implements ActiveRecord, PartedModule
      * Provides access the Phalcon application object.
      *
      * @see \Codeception\Lib\Connector\Phalcon::getApplication
-     * @return \Phalcon\Application|\Phalcon\Mvc\Micro
+     * @return \Phalcon\Mvc\Application|\Phalcon\Mvc\Micro
      */
     public function getApplication()
     {


### PR DESCRIPTION
`\Phalcon\Application` does not exist: https://github.com/phalcon/cphalcon/tree/4.1.2-release/phalcon/Application