### PR TITLE
Fixed ->getContent() return value, null is not accept for getRawBody()

### DIFF
--- a/src/Codeception/Lib/Connector/Phalcon4.php
+++ b/src/Codeception/Lib/Connector/Phalcon4.php
@@ -117,7 +117,8 @@ class Phalcon4 extends AbstractBrowser
         if ($di->has('request')) {
             $di->remove('request');
         }
-        $di['request'] = Stub::construct($phRequest, [], ['getRawBody' => $request->getContent()]);
+        $requestContent = $request->getContent() ?: '';
+        $di['request'] = Stub::construct($phRequest, [], ['getRawBody' => $requestContent]);
 
         $response = $application->handle($pathString);
         if (!$response instanceof Http\ResponseInterface) {


### PR DESCRIPTION
As title.

Cause `$request->getContent()` may return the `NULL` value, and `getRawBody` need to return type of String.